### PR TITLE
Use `ek_ini` for interfacing with the library

### DIFF
--- a/examples/1/Makefile
+++ b/examples/1/Makefile
@@ -6,9 +6,9 @@ TARGET := example.out
 SRCS := main.c
 OBJS := $(filter %.o, $(patsubst %.c, %.o, $(SRCS)))
 
-CPPFLAGS := -Wall -Wextra -O2
+CPPFLAGS := -Wall -Wextra
 
-.PHONY: all clean clang-format
+.PHONY: all clean
 
 $(TARGET): $(OBJS)
 	$(CC) -o $(TARGET) $(OBJS) -leasykey
@@ -16,7 +16,4 @@ $(TARGET): $(OBJS)
 all: $(TARGET)
 
 clean:
-	-@rm -rf $(TARGET) $(PACKAGE) $(OBJS)
-
-clang-format:
-	clang-format -style=llvm -i $(SRCS)
+	-@rm -rf $(TARGET) $(OBJS)

--- a/examples/1/main.c
+++ b/examples/1/main.c
@@ -34,17 +34,17 @@ ek_key Key = {"section2", "NAME", NULL};
 
 int main() {
   // Load the ini file to memory.
-  ek_key Ini[64]; // 64 being the most keys to read in.
-  int Count = iniLoad(IniFile, Ini);
+  ek_ini Ini = EK_INI_DEFAULT; // 64 being the most keys to read in.
+  iniLoad(IniFile, &Ini);
 
   // Get the key.
-  iniGetKey(Ini, Count, &Key);
+  iniGetKey(Ini, &Key);
 
   // Print the contents of the key.
   printf("Key '%s' contains: '%s'\n", Key.Name, Key.Data);
 
   // Free up our memory to avoid any leaks.
-  iniFree(Ini, Count);
+  iniFree(&Ini);
 
   return 0;
 }

--- a/examples/1/main.c
+++ b/examples/1/main.c
@@ -33,8 +33,9 @@ SOFTWARE.
 ek_key Key = {"section2", "NAME", NULL};
 
 int main() {
+  ek_ini Ini = EK_INI_DEFAULT;
+  
   // Load the ini file to memory.
-  ek_ini Ini = EK_INI_DEFAULT; // 64 being the most keys to read in.
   iniLoad(IniFile, &Ini);
 
   // Get the key.

--- a/examples/2/Makefile
+++ b/examples/2/Makefile
@@ -6,9 +6,9 @@ TARGET := example.out
 SRCS := main.c
 OBJS := $(filter %.o, $(patsubst %.c, %.o, $(SRCS)))
 
-CPPFLAGS := -Wall -Wextra -O2
+CPPFLAGS := -Wall -Wextra
 
-.PHONY: all clean clang-format
+.PHONY: all clean
 
 $(TARGET): $(OBJS)
 	$(CC) -o $(TARGET) $(OBJS) -leasykey
@@ -16,7 +16,4 @@ $(TARGET): $(OBJS)
 all: $(TARGET)
 
 clean:
-	-@rm -rf $(TARGET) $(PACKAGE) $(OBJS)
-
-clang-format:
-	clang-format -style=llvm -i $(SRCS)
+	-@rm -rf $(TARGET) $(OBJS)

--- a/examples/2/main.c
+++ b/examples/2/main.c
@@ -36,26 +36,26 @@ char *Value = "Pears Oranges";
 
 int main() {
   // Load the ini file to memory.
-  ek_key Ini[64];
-  int Count = iniLoad(IniFile, Ini);
+  ek_ini Ini = EK_INI_DEFAULT;
+  iniLoad(IniFile, &Ini);
 
   // Get the key.
-  iniGetKey(Ini, Count, &Key);
+  iniGetKey(Ini, &Key);
 
   printf("Key '%s' contains: '%s'...\n", Key.Name, Key.Data);
 
   // Set the key.
   Key.Data = Value;
 
-  iniSetKey(Ini, &Count, Key);
+  iniSetKey(&Ini, Key);
 
-  iniGetKey(Ini, Count, &Key);
+  iniGetKey(Ini, &Key);
   printf("And now key '%s' contains: '%s'.\n", Key.Name, Key.Data);
 
-  iniFlush(IniFile, Ini, Count);
+  iniFlush(IniFile, Ini);
 
   // Free up our memory to avoid any leaks.
-  iniFree(Ini, Count);
+  iniFree(&Ini);
 
   return 0;
 }

--- a/examples/2/main.c
+++ b/examples/2/main.c
@@ -35,8 +35,9 @@ ek_key Key = {"section1", "FRUITS", NULL};
 char *Value = "Pears Oranges";
 
 int main() {
-  // Load the ini file to memory.
   ek_ini Ini = EK_INI_DEFAULT;
+
+  // Load the ini file to memory.
   iniLoad(IniFile, &Ini);
 
   // Get the key.
@@ -52,6 +53,7 @@ int main() {
   iniGetKey(Ini, &Key);
   printf("And now key '%s' contains: '%s'.\n", Key.Name, Key.Data);
 
+  // Flush the ini data back to disk.
   iniFlush(IniFile, Ini);
 
   // Free up our memory to avoid any leaks.

--- a/include/easykey.h.in
+++ b/include/easykey.h.in
@@ -32,6 +32,9 @@ SOFTWARE.
 
 #define EK_VER "v@easykey_VERSION_MAJOR@.@easykey_VERSION_MINOR@"
 
+#define EK_INI_DEFAULT                                                         \
+  { 0, NULL }
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -42,12 +45,17 @@ typedef struct ek_key {
   char *Data;
 } ek_key;
 
-int iniLoad(const char *Filename, ek_key *Keys);
-void iniFlush(const char *Filename, ek_key *Keys, int Count);
-void iniFree(ek_key *Keys, int Count);
+typedef struct ek_ini {
+  int Count;
+  ek_key *Keys;
+} ek_ini;
 
-char *iniGetKey(const ek_key *Keys, int Count, ek_key *Key);
-void iniSetKey(ek_key *Keys, int *Count, const ek_key Key);
+void iniLoad(const char *Filename, ek_ini *Ini);
+void iniFlush(const char *Filename, ek_ini Ini);
+void iniFree(ek_ini *Ini);
+
+char *iniGetKey(const ek_ini Ini, ek_key *Key);
+void iniSetKey(ek_ini *Ini, const ek_key Key);
 
 #ifdef __cplusplus
 }

--- a/source/flush.c
+++ b/source/flush.c
@@ -32,18 +32,18 @@ SOFTWARE.
 /*
 Flushes the contents of 'ek_ini Ini' back to disk.
 */
-void iniFlush(const char *Filename, ek_key *Keys, int Count) {
+void iniFlush(const char *Filename, ek_ini Ini) {
   FILE *File = fopen(Filename, "w+");
   if (File != NULL) {
     char *Section = strdup("default");
     int i;
-    for (i = 0; i < Count; i++) {
-      if (strcmp(Keys[i].Section, Section)) {
+    for (i = 0; i < Ini.Count; i++) {
+      if (strcmp(Ini.Keys[i].Section, Section)) {
         free(Section);
-        Section = strdup(Keys[i].Section);
+        Section = strdup(Ini.Keys[i].Section);
         fprintf(File, "[%s]\n", Section);
       }
-      fprintf(File, "%s=%s\n", Keys[i].Name, Keys[i].Data);
+      fprintf(File, "%s=%s\n", Ini.Keys[i].Name, Ini.Keys[i].Data);
     }
     free(Section);
     fclose(File);

--- a/source/free.c
+++ b/source/free.c
@@ -28,12 +28,14 @@ SOFTWARE.
 
 #include "easykey.h"
 
-void iniFree(ek_key *Keys, int Count) {
-  // Free up data.
+void iniFree(ek_ini *Ini) {
   int i;
-  for (i = 0; i < Count; i++) {
-    free(Keys[i].Section);
-    free(Keys[i].Name);
-    free(Keys[i].Data);
+  for (i = 0; i < Ini->Count; i++) {
+    free(Ini->Keys[i].Section);
+    free(Ini->Keys[i].Name);
+    free(Ini->Keys[i].Data);
   }
+  free(Ini->Keys);
+  Ini->Count = 0;
+  Ini->Keys = NULL;
 }

--- a/source/get.c
+++ b/source/get.c
@@ -32,12 +32,12 @@ SOFTWARE.
 /*
 Retrieves a key's value.
 */
-char *iniGetKey(const ek_key *Keys, int Count, ek_key *Key) {
+char *iniGetKey(const ek_ini Ini, ek_key *Key) {
   int i;
-  for (i = 0; i < Count; i++)
-    if (!strcmp(Keys[i].Section, Key->Section) &&
-        !strcmp(Keys[i].Name, Key->Name)) {
-      Key->Data = Keys[i].Data;
+  for (i = 0; i < Ini.Count; i++)
+    if (!strcmp(Ini.Keys[i].Section, Key->Section) &&
+        !strcmp(Ini.Keys[i].Name, Key->Name)) {
+      Key->Data = Ini.Keys[i].Data;
       break;
     }
   return Key->Data;

--- a/source/load.c
+++ b/source/load.c
@@ -46,13 +46,19 @@ char *trimLeft(char *s) {
 Loads data from an ini file into an array of keys *Keys'. Return value is the
 number of keys read and allocated for.
 */
-int iniLoad(const char *Filename, ek_key *Keys) {
-  int Count = 0;
+void iniLoad(const char *Filename, ek_ini *Ini) {
+  int n = 16;
+  Ini->Keys = calloc(n, sizeof(ek_key));
+  Ini->Count = 0;
   FILE *File = fopen(Filename, "r+");
   if (File != NULL) {
     char *Section = strdup("default");
     char *Line = NULL;
     while (readLine(&Line, File) != -1) {
+      if (Ini->Count >= n) {
+        n += 16;
+        Ini->Keys = realloc(Ini->Keys, n * sizeof(ek_key));
+      }
       // Cut off any existing comment.
       char *Str;
       Str = strchr(Line, ';');
@@ -72,21 +78,20 @@ int iniLoad(const char *Filename, ek_key *Keys) {
         Section = strdup(strtok(&Line[1], "]"));
       } else if (strchr(Line, '=') != NULL) {
         // Copy in the key.
-        Keys[Count].Section = strdup(Section);
-        Keys[Count].Data = strdup(trimLeft(strchr(Line, '=') + 1));
-        Keys[Count].Name = strdup(strtok(strtok(Line, "="), " "));
-        Count++;
+        Ini->Keys[Ini->Count].Section = strdup(Section);
+        Ini->Keys[Ini->Count].Data = strdup(trimLeft(strchr(Line, '=') + 1));
+        Ini->Keys[Ini->Count].Name = strdup(strtok(strtok(Line, "="), " "));
+        Ini->Count++;
       } else if (strchr(Line, ':') != NULL) {
         // Copy in the key.
-        Keys[Count].Section = strdup(Section);
-        Keys[Count].Data = strdup(trimLeft(strchr(Line, ':') + 1));
-        Keys[Count].Name = strdup(strtok(strtok(Line, ":"), " "));
-        Count++;
+        Ini->Keys[Ini->Count].Section = strdup(Section);
+        Ini->Keys[Ini->Count].Data = strdup(trimLeft(strchr(Line, ':') + 1));
+        Ini->Keys[Ini->Count].Name = strdup(strtok(strtok(Line, ":"), " "));
+        Ini->Count++;
       }
     }
     free(Line);
     free(Section);
     fclose(File);
   }
-  return Count;
 }

--- a/source/set.c
+++ b/source/set.c
@@ -34,20 +34,21 @@ Sets a key's value. Note that if the key to be set does not already exist, then
 the data may be out of sort. Doesn't really matter to the program, but the ini
 file will become segmented.
 */
-void iniSetKey(ek_key *Keys, int *Count, const ek_key Key) {
+void iniSetKey(ek_ini *Ini, const ek_key Key) {
   int i;
-  for (i = 0; i < *Count; i++)
+  for (i = 0; i < Ini->Count; i++)
     // Get to the key.
-    if (!strcmp(Keys[i].Section, Key.Section) &&
-        !strcmp(Keys[i].Name, Key.Name)) {
-      strcpy(Keys[i].Data, Key.Data);
+    if (!strcmp(Ini->Keys[i].Section, Key.Section) &&
+        !strcmp(Ini->Keys[i].Name, Key.Name)) {
+      strcpy(Ini->Keys[i].Data, Key.Data);
       return;
     }
   // If we get this far, then the key does not exist. Add it to the last entry.
   // NOTE: This assumes there is space in the 'Keys' array for the new key.
-  Keys[*Count].Section = strdup(Key.Section);
-  Keys[*Count].Name = strdup(Key.Name);
-  Keys[*Count].Data = strdup(Key.Data);
-  (*Count)++;
+  Ini->Keys = realloc(Ini->Keys, sizeof(ek_key) * (Ini->Count + 1));
+  Ini->Keys[Ini->Count].Section = strdup(Key.Section);
+  Ini->Keys[Ini->Count].Name = strdup(Key.Name);
+  Ini->Keys[Ini->Count].Data = strdup(Key.Data);
+  (Ini->Count)++;
   // TODO: Sort?
 }


### PR DESCRIPTION
Instead of having to pass an array of keys and a count to most functions, combine the two into a struct that gets passed instead.

Also, this allows a fully dynamic amount of keys, as opposed to the previous method where you would define a static array size beforehand. It also prevents possible memory errors due to the fact that it cannot overflow with keys.

Changes to many functions and their parameters have been made.